### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,10 @@ include = [
 	"RELEASES.md",
 ]
 
-[badges]
-travis-ci = { repository = "qu1x/bml" }
 
 [dependencies]
 thiserror = "1"
 pest = "2"
 pest_derive = "2"
-smartstring = "0.2"
-ordered-multimap = "0.3"
+smartstring = "1.0.1"
+ordered-multimap = "0.6.0"


### PR DESCRIPTION
* Updates smartstring to 1.0.1 and ordered-multimap to 0.6.0

I was experiencing a panic with smartstring on the current version when trying to parse https://github.com/hizzlekizzle/quark-shaders/blob/51fa84deca4e805f3bea1e7e2fbe583d82833cc4/CRT-Royale.shader/manifest.bml